### PR TITLE
util: Improve scaling pattern download scripts & their docs

### DIFF
--- a/util/surface/assets/scaling_patterns/01_download.sh
+++ b/util/surface/assets/scaling_patterns/01_download.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
-mkdir -p data/src
-cd data/src
-wget https://github.com/JGCRI/hectorui/raw/main/inst/shinyApp/www/maps/tas_Amon_CanESM2_esmrcp85_r1i1p1_200601-210012_pattern.rds
-wget https://github.com/JGCRI/hectorui/raw/main/inst/shinyApp/www/maps/tas_Amon_CESM1-BGC_rcp85_r1i1p1_200601-210012_pattern.rds
-wget https://github.com/JGCRI/hectorui/raw/main/inst/shinyApp/www/maps/tas_Amon_GFDL-ESM2G_rcp85_r1i1p1_200601-210012_pattern.rds
-wget https://github.com/JGCRI/hectorui/raw/main/inst/shinyApp/www/maps/tas_Amon_MIROC-ESM_esmrcp85_r1i1p1_200601-210012_pattern.rds
-wget https://github.com/JGCRI/hectorui/raw/main/inst/shinyApp/www/maps/tas_Amon_MPI-ESM-LR_esmrcp85_r1i1p1_200601-210012_pattern.rds
-wget https://github.com/JGCRI/hectorui/raw/main/inst/shinyApp/www/maps/tas_Amon_MRI-ESM1_esmrcp85_r1i1p1_200601-210012_pattern.rds
-wget https://github.com/JGCRI/hectorui/raw/main/inst/shinyApp/www/maps/pr_Amon_CanESM2_rcp85_r1i1p1_200601-210012_pattern.rds
-wget https://github.com/JGCRI/hectorui/raw/main/inst/shinyApp/www/maps/pr_Amon_CESM1-BGC_rcp85_r1i1p1_200601-210012_pattern.rds
-wget https://github.com/JGCRI/hectorui/raw/main/inst/shinyApp/www/maps/pr_Amon_GFDL-ESM2G_rcp85_r1i1p1_200601-210012_pattern.rds
-wget https://github.com/JGCRI/hectorui/raw/main/inst/shinyApp/www/maps/pr_Amon_MIROC-ESM_rcp85_r1i1p1_200601-210012_pattern.rds
-wget https://github.com/JGCRI/hectorui/raw/main/inst/shinyApp/www/maps/pr_Amon_MPI-ESM-LR_rcp85_r1i1p1_200601-210012_pattern.rds
-wget https://github.com/JGCRI/hectorui/raw/main/inst/shinyApp/www/maps/pr_Amon_MRI-ESM1_rcp85_r1i1p1_200601-210012_pattern.rds
+
+dl_dir="data/src"
+dl_url="https://github.com/JGCRI/hectorui/raw/main/inst/shinyApp/www/maps"
+
+mkdir -p "$dl_dir"
+
+for file in \
+  pr_Amon_CanESM2_rcp85_r1i1p1_200601-210012_pattern.rds        \
+  pr_Amon_CESM1-BGC_rcp85_r1i1p1_200601-210012_pattern.rds      \
+  pr_Amon_GFDL-ESM2G_rcp85_r1i1p1_200601-210012_pattern.rds     \
+  pr_Amon_MIROC-ESM_rcp85_r1i1p1_200601-210012_pattern.rds      \
+  pr_Amon_MPI-ESM-LR_rcp85_r1i1p1_200601-210012_pattern.rds     \
+  pr_Amon_MRI-ESM1_rcp85_r1i1p1_200601-210012_pattern.rds       \
+  tas_Amon_CanESM2_esmrcp85_r1i1p1_200601-210012_pattern.rds    \
+  tas_Amon_CESM1-BGC_rcp85_r1i1p1_200601-210012_pattern.rds     \
+  tas_Amon_GFDL-ESM2G_rcp85_r1i1p1_200601-210012_pattern.rds    \
+  tas_Amon_MIROC-ESM_esmrcp85_r1i1p1_200601-210012_pattern.rds  \
+  tas_Amon_MPI-ESM-LR_esmrcp85_r1i1p1_200601-210012_pattern.rds \
+  tas_Amon_MRI-ESM1_esmrcp85_r1i1p1_200601-210012_pattern.rds
+do
+  curl --silent --output="$dl_dir"/"$file" "$dl_url"/"$file"
+done

--- a/util/surface/assets/scaling_patterns/01_download.sh
+++ b/util/surface/assets/scaling_patterns/01_download.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 dl_dir="data/src"
-dl_url="https://github.com/JGCRI/hectorui/raw/main/inst/shinyApp/www/maps"
+dl_sha="a0216e5e2e7493d089d183beeda5d2f9ddcbb592"
+dl_url="https://github.com/JGCRI/hectorui/raw/$dl_sha/inst/shinyApp/www/maps"
 
 mkdir -p "$dl_dir"
 

--- a/util/surface/assets/scaling_patterns/readme.md
+++ b/util/surface/assets/scaling_patterns/readme.md
@@ -1,5 +1,12 @@
 The scaling patterns are used to spatialize global temperature averages into a 320x160 grid.
 
-1. Run `01_download.sh` to download the original scaling pattern data.
-2. Run `02_convert.py` to convert the scaling patterns into `.npz` files and generate an include file for Rust.
-3. (Optional) Run `03_preview.py` to preview the pattern outputs.
+1. Run the below scripts, to:
+   1. Download the original scaling pattern data.
+   2. Convert them into `.npz` files and generate an include file for Rust.
+   3. (Optional) Preview the pattern outputs.
+
+```shell
+bash   01_download.sh
+python 02_convert.py
+# python 03_preview.py
+```


### PR DESCRIPTION
I noticed that the `wget` dependency wasn't documented, and since the `raw/main`-URLs were also all broken, I overhauled that script a bit.

I think this also helps speed it up a bit (excluding the download duration):

```
# with wget
$ hyperfine -i "bash ./util/surface/assets/scaling_patterns/01_download.sh"
  Time (mean ± σ):      2.187 s ±  0.958 s    [User: 0.288 s, System: 0.112 s]
  Range (min … max):    1.316 s …  4.235 s    10 runs

  Warning: Ignoring non-zero exit code.
  # due to `main`

# with curl
$ hyperfine -i "bash ./util/surface/assets/scaling_patterns/01_download.sh"
  Time (mean ± σ):     182.2 ms ±   5.1 ms    [User: 54.7 ms, System: 83.1 ms]
  Range (min … max):   177.9 ms … 197.6 ms    15 runs
```